### PR TITLE
Python 3 support

### DIFF
--- a/astrid/__init__.py
+++ b/astrid/__init__.py
@@ -54,7 +54,7 @@ class BuildLogger:
         headerTo = cherrypy.config.get("mail_to")
 
         msg = MIMEText(message)
-        msg['Subject'] = 'Astrid coughed on repo %s' % reponame
+        msg['Subject'] = 'Astrid coughed on repo {}'.format(reponame)
         msg['From'] = headerFrom
         msg['To'] = headerTo
 
@@ -66,7 +66,7 @@ class BuildLogger:
             pass
 
 
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 
 REPOS_INI = '~/.astrid/repos.ini'
 CONFIG_INI = '~/.astrid/config.ini'

--- a/astrid/pages.py
+++ b/astrid/pages.py
@@ -8,7 +8,7 @@ import sys
 import time
 
 from git import Repo, Git, GitCommandError
-from ConfigParser import ConfigParser
+from configparser import ConfigParser
 
 from astrid import BuildLogger
 from astrid.templating import Template
@@ -53,18 +53,18 @@ class BuilderPage(BasePage):
                 repo = self._updateRepo(reponame)
                 try:
                     if self._build(reponame):
-                        msg = """#%s Build succeeded.""" % repo.head.commit.hexsha[0:6]
+                        msg = "#{} Build succeeded.".format(repo.head.commit.hexsha[0:6])
                         msg_class = "green"
                         time_end = time.time()
                     else:
-                        msg = """#%s Build failed.""" % repo.head.commit.hexsha[0:6]
+                        msg = "#{} Build failed.".format(repo.head.commit.hexsha[0:6])
                         msg_class = "red"
                 except:
-                    msg = """#%s Build error.""" % repo.head.commit.hexsha[0:6]
+                    msg = "#{} Build error.".format(repo.head.commit.hexsha[0:6])
                     msg_class = "red"
                     raise
             except GitCommandError as e:
-                msg = "Pull error. (" + str(e) + ")"
+                msg = "Pull error. ({})".format(str(e))
                 msg_class = "red"
                 sendMail = True
                 raise
@@ -132,7 +132,7 @@ class BuilderPage(BasePage):
         args = self.repos.get(reponame, "build_args")
         cwd = os.path.join(self.repodir, reponame)
         
-        logfilename = os.path.expanduser("~/.astrid/%s.build.log" % reponame)
+        logfilename = os.path.expanduser("~/.astrid/{}.build.log".format(reponame))
         logfile = open(logfilename, "w")
         p = subprocess.Popen(["sudo", "-u", usr, cmd] + shlex.split(args), cwd=cwd, stdout=logfile, stderr=logfile, stdin=open("/dev/null"))
         p.wait()        
@@ -154,10 +154,10 @@ class InfoPage(BasePage):
         for record in logger.getLogs(reponame):
             record += ['']*(3-len(record))
             if first:
-                msg += """<tr><td>%s</td><td><a href="../buildlog/%s">%s</a></td><td>%s</td></tr>""" % (record[0], reponame, record[1],record[2],)
+                msg += """<tr><td>{}</td><td><a href="../buildlog/{}">{}</a></td><td>{}</td></tr>""".format(record[0], reponame, record[1], record[2])
                 first = False
             else:
-                msg += """<tr><td>%s</td><td>%s</td><td>%s</td></tr>""" % (record[0], record[1],record[2],)
+                msg += """<tr><td>{}</td><td>{}</td><td>{}</td></tr>""".format(record[0], record[1], record[2])
             
         msg += "</table>"
         
@@ -216,7 +216,7 @@ class DashboardPage(BasePage):
             if user in self.repos.get(section, "users").split(","):
                 building = self._isBuilding(section)
                 building = ', building&hellip;' if building else ''
-                repos += """<li><a href="%s">%s</a> (<a href="info/%s">info</a>%s)</li>""" % (section, section, section,building,)
+                repos += """<li><a href="{}">{}</a> (<a href="info/{}">info</a>{})</li>""".format(section, section, section, building)
                 
         template.assignData("pagetitle", "Astrid")
         template.assignData("repos", repos)

--- a/astrid/templating.py
+++ b/astrid/templating.py
@@ -1,5 +1,5 @@
 import os
-import cgi
+import html
 import re
 import os.path
 import pkg_resources
@@ -15,7 +15,7 @@ class Template:
         
     def render(self):
         # firstly include files        
-        template = pkg_resources.resource_stream('astrid', self.filename).read()
+        template = pkg_resources.resource_stream('astrid', self.filename).read().decode()
         template = re.sub('\{include ([^\}]*)\}', self._include, template)
         # secondly expand variables
         return re.sub('\{(!)?([^\}]*)\}', self._expand, template)
@@ -27,7 +27,7 @@ class Template:
             if not f:
                 self.includes[filename] = "NOT FOUND"
             else:
-                self.includes[filename] = f.read()
+                self.includes[filename] = f.read().decode()
                 f.close()
         
         return self.includes[filename]
@@ -38,7 +38,7 @@ class Template:
         else:
             data = "undefined"     
         if mo.group(1) == "!":
-            return cgi.escape(data)
+            return html.escape(data)
         else:
             return data
             

--- a/bin/astrid
+++ b/bin/astrid
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 
 import cherrypy
 import astrid
@@ -19,7 +19,7 @@ elif argc == 2 and sys.argv[1] == '-d':
 elif argc == 3 and sys.argv[1] == '-d':
     pidfile = sys.argv[2]
 else:
-    print("Usage: %s [-d [pidfile]]" % sys.argv[0])
+    print("Usage: {} [-d [pidfile]]".format(sys.argv[0]))
     sys.exit(1)
 
 if daemon:

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 VERSION=`git describe HEAD --tags`
-python setup.py $VERSION bdist_egg
+python3 setup.py $VERSION bdist_egg


### PR DESCRIPTION
Python 2 is at the end of life, let's move to Python 3.

Converted using 2to3 script and tested, so it should be safe to deploy. Although there still may be some non-idiomatic constructions and obsolete library function calls.